### PR TITLE
Make private methods/properties protected

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,9 @@ php:
   - 5.4
   - 5.5
   - 5.6
+  - 7.0
+  - 7.1
+  - 7.2
   - hhvm
 before_script:
   - composer self-update

--- a/src/Drip.php
+++ b/src/Drip.php
@@ -4,14 +4,14 @@ namespace DrewM\Drip;
 
 class Drip
 {
-	private $api_endpoint = 'https://api.getdrip.com/v2';
+	protected $api_endpoint = 'https://api.getdrip.com/v2';
 
-	private static $eventSubscriptions = [];
-	private static $receivedWebhook = false;
+	protected static $eventSubscriptions = [];
+	protected static $receivedWebhook = false;
 	
-	private $token      = false;
-	private $accountID  = false;
-	private $verify_ssl = true;
+	protected $token      = false;
+	protected $accountID  = false;
+	protected $verify_ssl = true;
 
 	public function __construct($token, $accountID)
 	{
@@ -64,7 +64,7 @@ class Drip
 		return false;
 	}
 
-	private static function processWebhook($input) 
+	protected static function processWebhook($input) 
 	{
 		if ($input) {
 			self::$receivedWebhook = $input;
@@ -78,7 +78,7 @@ class Drip
 		return false;
 	}
 
-	private static function dispatchWebhookEvent($event, $data)
+	protected static function dispatchWebhookEvent($event, $data)
 	{
 		if (isset(self::$eventSubscriptions[$event])) {
 			foreach(self::$eventSubscriptions[$event] as $callback) {
@@ -90,11 +90,11 @@ class Drip
 		return false;
 	}
 
-	private function makeRequest($http_verb='post', $api_method, $args=array(), $timeout=10)
+	protected function makeRequest($http_verb='post', $api_method, $args=array(), $timeout=10)
 	{
 		$url = $this->api_endpoint.'/'.$this->accountID.'/'.$api_method;
         
-        if (function_exists('curl_init') && function_exists('curl_setopt')) {
+		if (function_exists('curl_init') && function_exists('curl_setopt')) {
 
 			$ch = curl_init(); 
 			curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1); 

--- a/src/Response.php
+++ b/src/Response.php
@@ -8,7 +8,7 @@ class Response
 	public $error   = null;
 	public $message = null;
 
-	private $data   = [];
+	protected $data   = [];
 
 	public function __construct($meta, $body)
 	{
@@ -40,14 +40,14 @@ class Response
 		return $this->data;
 	}
 
-	private function process_meta($meta)
+	protected function process_meta($meta)
 	{
 		if (isset($meta['http_code'])) {
 			$this->status = (int) $meta['http_code'];	
 		}
 	}
 
-	private function process_body($body)
+	protected function process_body($body)
 	{
 		$decoded_body = json_decode($body, true); 
 		if (is_array($decoded_body)) {
@@ -55,7 +55,7 @@ class Response
 		}
 	}
 
-	private function handle_errors()
+	protected function handle_errors()
 	{
 		if (is_array($this->data) && isset($this->data['errors'])) {
 			$this->error = $this->data['errors'][0]['code'];


### PR DESCRIPTION
So `Drip` and `Response` classes could be extended.

Fixes #4.